### PR TITLE
feat: add NotFound page and route for handling 404 errors

### DIFF
--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center p-8">
+      <h1 className="text-5xl font-extrabold text-gray-900 mb-4">404</h1>
+      <p className="text-lg text-gray-600 mb-8">找不到頁面 Page not found</p>
+      <div className="flex gap-3">
+        <Link to="/">
+          <span className="inline-block bg-blue-600 hover:bg-blue-700 text-white rounded px-4 py-2">回到首頁 Home</span>
+        </Link>
+        <Link to="/map">
+          <span className="inline-block border border-gray-300 hover:bg-gray-50 text-gray-800 rounded px-4 py-2">前往地圖 Map</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -14,6 +14,8 @@ import GridMonitor from "./GridMonitor";
 
 import RequestHelp from "./RequestHelp";
 
+import NotFound from "./NotFound";
+
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
 const PAGES = {
@@ -73,6 +75,7 @@ function PagesContent() {
                 
                 <Route path="/RequestHelp" element={<RequestHelp />} />
                 
+                <Route path="*" element={<NotFound />} />
             </Routes>
         </Layout>
     );


### PR DESCRIPTION
<img width="1734" height="750" alt="截圖 2025-10-02 下午4 42 55" src="https://github.com/user-attachments/assets/b53220da-82a2-4894-85cf-f05ce926d441" />

新增了一個 NotFound 頁面，並設定對應的路由，用於統一處理使用者存取不存在頁面時的 404 錯誤。

### 📝 變更內容
- 🆕 新增 NotFound 元件頁面
- 🔗 新增 404 錯誤對應的路由設定
- 🚫 未匹配路徑將自動導向至 NotFound 頁面

### 📌 影響範圍
- 🌐 使用者存取不存在的 URL 時，將會正確顯示 404 頁面