### PR TITLE
fix: adjust text size for better responsiveness in header

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -90,8 +90,8 @@ export default function Layout({ children, currentPageName }) {
                 <MapPin className="w-6 h-6 text-white" />
               </div>
               <div className="hidden sm:block">
-                <h1 className="text-xl font-bold text-gray-900">鏟子英雄</h1>
-                <p className="text-xs text-gray-500">花蓮颱風救援對接</p>
+                <h1 className="text-xl md:text-sm lg:text-xl font-bold text-gray-900">鏟子英雄</h1>
+                <p className="text-xs md:hidden lg:text-xs text-gray-500">花蓮颱風救援對接</p>
               </div>
             </Link>
 


### PR DESCRIPTION
## Original issue
#25 標題跑版

## Resolution
- 姑且在這個寬度區間先把副標題藏起來

## Before
<img width="1702" height="1620" alt="image" src="https://github.com/user-attachments/assets/58b5a9d1-9172-47c6-aef7-0c210200d596" />


## After
<img width="857" height="618" alt="截圖 2025-10-02 晚上10 09 00" src="https://github.com/user-attachments/assets/d11fb397-d1e7-440a-8916-aab1921453aa" />
