### PR TITLE
feat: 更新響應式設計，新增自訂斷點以改善標題顯示

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -89,9 +89,13 @@ export default function Layout({ children, currentPageName }) {
               <div className="w-10 h-10 bg-gradient-to-r from-red-500 to-orange-500 rounded-xl flex items-center justify-center">
                 <MapPin className="w-6 h-6 text-white" />
               </div>
-              <div className="hidden sm:block">
+              <div className="block md:hidden">
                 <h1 className="text-xl font-bold text-gray-900">鏟子英雄</h1>
                 <p className="text-xs text-gray-500">花蓮颱風救援對接</p>
+              </div>
+              <div className="hidden md:block">
+                <h1 className="text-xl font-bold text-gray-900 hidden title:block">鏟子英雄</h1>
+                <p className="text-xs text-gray-500 hidden subtitle:block">花蓮颱風救援對接</p>
               </div>
             </Link>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,15 @@ module.exports = {
     darkMode: ["class"],
     content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
+    screens: {
+      'sm': '640px',
+      'md': '768px',
+      'title': '860px',  // 自訂斷點：主標題
+      'subtitle': '1095px', // 自訂斷點：副標題
+      'lg': '1024px',
+      'xl': '1280px',
+      '2xl': '1536px',
+    },
   	extend: {
   		borderRadius: {
   			lg: 'var(--radius)',


### PR DESCRIPTION
### Original issue
https://github.com/shovel-heroes-org/shovel-heroes/issues/25 標題跑版

### Resolution

標題顯示邏輯說明
斷點設定
在 [tailwind.config.js](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 中定義了以下自訂斷點：

顯示邏輯
手機版面（< 768px）
Mobile Menu Button 顯示
完整顯示主標題「鏟子英雄」和副標題「花蓮颱風救援對接」
導航選單收合在漢堡選單中

平板到小桌面（768px - 860px）
Mobile Menu Button 隱藏
主標題和副標題都隱藏
導航選單展開顯示
<img width="1112" height="1113" alt="Base44-APP-10-02-2025_11_19_PM" src="https://github.com/user-attachments/assets/cd15bc34-c43c-4bb3-ba2a-90c45716096c" />

中等桌面（860px - 1095px）
Mobile Menu Button 隱藏
主標題「鏟子英雄」顯示
副標題仍然隱藏
導航選單展開顯示
<img width="1375" height="672" alt="Base44-APP-10-02-2025_11_21_PM" src="https://github.com/user-attachments/assets/83a98aef-a166-49da-8921-fdaad028f751" />

大螢幕（>= 1095px）
Mobile Menu Button 隱藏
主標題「鏟子英雄」顯示
副標題「花蓮颱風救援對接」顯示
導航選單展開顯示
<img width="1858" height="660" alt="Base44-APP-10-02-2025_11_21_PM (1)" src="https://github.com/user-attachments/assets/4cdb674d-cd33-41a3-9157-fce2f60b33b9" />

程式碼實現

注意事項
手機版和桌面版使用不同的邏輯控制，確保在各種螢幕尺寸下都有最佳的顯示效果
使用 Tailwind 的響應式類別系統，確保程式碼的可維護性
標題的顯示邏輯與導航選單的顯示邏輯相互配合，提供一致的用戶體驗
未來擴展建議




