### PR TITLE
BugFix: 修正志工確認，將取消改成婉拒。

### DIFF
--- a/src/pages/Volunteers.jsx
+++ b/src/pages/Volunteers.jsx
@@ -129,7 +129,8 @@ export default function VolunteersPage() {
       case 'confirmed': return 'bg-blue-100 text-blue-800';
       case 'arrived': return 'bg-purple-100 text-purple-800';
       case 'completed': return 'bg-green-100 text-green-800';
-      case 'cancelled': return 'bg-red-100 text-red-800';
+      case 'declined': return 'bg-red-100 text-red-800';
+      case 'cancelled': return 'bg-gray-200 text-gray-700';
       default: return 'bg-gray-100 text-gray-800';
     }
   };
@@ -140,6 +141,7 @@ export default function VolunteersPage() {
       case 'confirmed': return '已確認';
       case 'arrived': return '已到場';
       case 'completed': return '已完成';
+      case 'declined': return '已婉拒';
       case 'cancelled': return '已取消';
       default: return status;
     }
@@ -370,10 +372,10 @@ export default function VolunteersPage() {
                                     size="sm"
                                     variant="outline"
                                     className="text-red-600 hover:text-red-700 border-red-200 hover:border-red-300"
-                                    onClick={() => handleStatusUpdate(registration, 'cancelled')}
+                                    onClick={() => handleStatusUpdate(registration, 'declined')}
                                   >
                                     <X className="w-4 h-4 mr-2" />
-                                    拒絕
+                                    婉拒
                                   </Button>
                                 </>
                               )}


### PR DESCRIPTION
This pull request introduces the ability to update the status of volunteer registrations with clear transition and permission rules, and improves the handling and display of declined and cancelled statuses in the volunteers UI. The backend now supports status updates with proper validation, while the frontend distinguishes between "declined" and "cancelled" for both logic and user interface presentation.

**Backend: Volunteer Registration Status Updates**
- Adds a new `PUT /volunteer-registrations/:id` endpoint to allow updating the status of a volunteer registration, enforcing valid status transitions (e.g., pending → confirmed/declined/cancelled, confirmed → arrived/cancelled) and permission checks (e.g., only privileged users can confirm/decline, self or privileged can cancel). Also updates grid volunteer counts accordingly.

**Frontend: Improved Status Handling and UI**
- Updates the status badge color logic in `VolunteersPage` to show "declined" registrations in red and "cancelled" in gray, improving visual distinction.
- Adds a display label for the "declined" status in Chinese ("已婉拒") in the volunteers list.
- Changes the "拒絕" (decline) button in the volunteers UI to update the status to "declined" instead of "cancelled", and updates the button label to "婉拒".