### PR TITLE
feat: 新增自訂斷點以改善手機版顯示效果

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -136,8 +136,8 @@ export default function Layout({ children, currentPageName }) {
                 <MapPin className="w-6 h-6 text-white" />
               </div>
               <div className="block md:hidden">
-                <h1 className="text-xl font-bold text-gray-900">鏟子英雄</h1>
-                <p className="text-xs text-gray-500">花蓮颱風救援對接</p>
+                <h1 className="text-xl font-bold text-gray-900 hidden xxs:block">鏟子英雄</h1>
+                <p className="text-xs text-gray-500 hidden xs:block">花蓮颱風救援對接</p>
               </div>
               <div className="hidden md:block">
                 <h1 className="text-xl font-bold text-gray-900 hidden title:block">鏟子英雄</h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,8 @@ module.exports = {
     content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
     screens: {
+	  'xxs': '450px',    // 自訂斷點：手機版主標題
+	  'xs': '510px',     // 自訂斷點：手機版副標題
       'sm': '640px',
       'md': '768px',
       'title': '860px',  // 自訂斷點：主標題


### PR DESCRIPTION
### Original issue
https://github.com/shovel-heroes-org/shovel-heroes/issues/39 標題跑版 新增響應式斷點
不和 https://github.com/shovel-heroes-org/shovel-heroes/issues/25 重複

### Resolution

顯示邏輯
極小螢幕 (< 450px)
只顯示 Logo 圖示
主標題和副標題都隱藏
Mobile Menu 按鈕顯示

小手機螢幕 (450px - 510px)
Logo 圖示
顯示主標題「鏟子英雄」
副標題隱藏
Mobile Menu 按鈕顯示

大手機螢幕 (510px - 768px)
Logo 圖示
顯示主標題「鏟子英雄」
顯示副標題「花蓮颱風救援對接」
Mobile Menu 按鈕顯示

### 修改前
<img width="488" height="565" alt="鏟子英雄-Shovel-Heroes--10-03-2025_10_01_AM" src="https://github.com/user-attachments/assets/778b43be-a8f0-4361-9364-2c62e984979b" />

### 修改後
<img width="561" height="2630" alt="鏟子英雄-Shovel-Heroes--10-03-2025_09_59_AM" src="https://github.com/user-attachments/assets/bb00cead-b002-4b0d-87e4-92205d8e7286" />


