### PR TITLE
fix: 修正 Map.jsx getSupplyShortage 函式型別錯誤 -> 影響畫面顯示空白

### DIFF
--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -547,7 +547,21 @@ export default function MapPage() {
   };
 
   const getSupplyShortage = (supplies) => {
-    return supplies?.filter(s => s.received < s.quantity) || [];
+    if (!supplies) return [];
+
+    if (Array.isArray(supplies)) {
+      return supplies.filter((s) => s.received < s.quantity);
+    }
+
+    if (typeof supplies === "object") {
+      return Object.entries(supplies).map(([name, quantity]) => ({
+        name,
+        quantity,
+        received: 0, // 預設為 0，因為物件格式沒有 received 資訊
+        unit: "個", // 假設單位為「個」，根據實際情況調整
+      }));
+    }
+    return [];
   };
 
   if (loading) {


### PR DESCRIPTION
- 加強 getSupplyShortage 函式的型別檢查
- 支援物件格式的 supplies 資料（如 {food: 36, tools: 28}）
- 保持向後相容陣列格式
- 修復首頁白畫面問題（TypeError: supplies?.filter is not a function