### PR TITLE
暫存表單資料於 Local Storage 開啟時帶入 送出時刪除

### DIFF
--- a/src/components/admin/AddGridModal.jsx
+++ b/src/components/admin/AddGridModal.jsx
@@ -200,17 +200,20 @@ export default function AddGridModal({ isOpen, onClose, onSuccess, disasterAreas
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    let newForm;
     setFormData((prev) => {
-      newForm = { ...prev, [name]: value };
+      const newForm = { ...prev, [name]: value };
+      updateLocalStorage("NewGrid", newForm);
       return newForm;
     });
-    updateLocalStorage("NewGrid", newForm);
   };
 
   const handleSelectChange = (name, value) => {
-    setFormData((prev) => ({ ...prev, [name]: value }));
-    updateLocalStorage({ ...prev, [name]: value });
+    setFormData((prev) => {
+      const newForm = { ...prev, [name]: value };
+      updateLocalStorage("NewGrid", newForm);
+      return newForm;
+    });
+  
     if (name === 'disaster_area_id') {
       const area = disasterAreas.find(a => a.id === value);
       if (area) {

--- a/src/components/admin/AddGridModal.jsx
+++ b/src/components/admin/AddGridModal.jsx
@@ -19,6 +19,7 @@ import { User } from '@/api/entities';
 import "leaflet/dist/leaflet.css";
 import { Loader2, Info } from 'lucide-react';
 import { AskForLoginModal } from '../login/AskForLoginModal';
+import { deleteLocalStorage, getLocalStorage, updateLocalStorage } from '@/lib/utils';
 
 const LocationPicker = ({ position, setPosition }) => {
   const map = useMap();
@@ -60,7 +61,7 @@ const MapController = ({ center, zoom }) => {
 }
 
 export default function AddGridModal({ isOpen, onClose, onSuccess, disasterAreas }) {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState(getLocalStorage("NewGrid") || {
     code: '',
     grid_type: 'manpower',
     disaster_area_id: '',
@@ -162,7 +163,7 @@ export default function AddGridModal({ isOpen, onClose, onSuccess, disasterAreas
       );
       
       // Reset form data and errors when modal opens
-      setFormData({
+      setFormData(getLocalStorage("NewGrid") || {
         code: '',
         grid_type: 'manpower',
         disaster_area_id: defaultArea ? defaultArea.id : '',
@@ -199,11 +200,17 @@ export default function AddGridModal({ isOpen, onClose, onSuccess, disasterAreas
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    let newForm;
+    setFormData((prev) => {
+      newForm = { ...prev, [name]: value };
+      return newForm;
+    });
+    updateLocalStorage("NewGrid", newForm);
   };
 
   const handleSelectChange = (name, value) => {
     setFormData((prev) => ({ ...prev, [name]: value }));
+    updateLocalStorage({ ...prev, [name]: value });
     if (name === 'disaster_area_id') {
       const area = disasterAreas.find(a => a.id === value);
       if (area) {
@@ -302,6 +309,7 @@ export default function AddGridModal({ isOpen, onClose, onSuccess, disasterAreas
       
       await Grid.create({ ...payload, __turnstile_token: turnstileToken });
       onSuccess();
+      deleteLocalStorage("NewGrid");
     } catch (err) {
       console.error('Failed to create grid:', err);
       setError('建立網格失敗，請稍後再試。');

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -22,21 +22,20 @@ import {
   PackagePlus, Send, Info,
   CalendarClock
 } from "lucide-react";
-import { formatCreatedDate } from "@/lib/utils";
+import { formatCreatedDate, getLocalStorage, updateLocalStorage, deleteLocalStorage } from "@/lib/utils";
 
 export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = "info", onTabChange }) {
-  const updateLocalStorage = (targetFormName, targetForm) => 
-    { window.localStorage.setItem(targetFormName + "-" + grid.id, JSON.stringify(targetForm)); }
+  const updateLSGrid = (targetFormName, targetForm) => updateLocalStorage(targetFormName + "-" + grid.id, JSON.stringify(targetForm));
 
-  const getLocalStorage = (targetFormName) => JSON.parse(window.localStorage.getItem(targetFormName + "-" + grid.id));
-  const deleteLocalStorage = (targetFormName) => {  window.localStorage.removeItem(targetFormName + "-" + grid.id);  }
+  const getLSGrid = (targetFormName) => getLocalStorage(targetFormName + "-" + grid.id);
+  const deleteLSGrid = (targetFormName) => deleteLocalStorage(targetFormName + "-" + grid.id);
 
   // Normalize supplies_needed to an array to avoid runtime errors if backend returns null
   if (!Array.isArray(grid.supplies_needed)) {
     grid = { ...grid, supplies_needed: [] };
   }
   const [activeTab, setActiveTab] = useState(defaultTab);
-  const [volunteerForm, setVolunteerForm] = useState(getLocalStorage("volunteer", grid.id) || {
+  const [volunteerForm, setVolunteerForm] = useState(getLSGrid("volunteer", grid.id) || {
     volunteer_name: "",
     volunteer_phone: "",
     volunteer_email: "",
@@ -45,7 +44,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     equipment: "",
     notes: ""
   });
-  const [supplyForm, setSupplyForm] = useState(getLocalStorage("supply", grid.id) || {
+  const [supplyForm, setSupplyForm] = useState(getLSGrid("supply", grid.id) || {
     donor_name: "",
     donor_phone: "",
     donor_email: "",
@@ -56,7 +55,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     delivery_time: "",
     notes: ""
   });
-  const [discussionForm, setDiscussionForm] = useState(getLocalStorage("discussion", grid.id) || {
+  const [discussionForm, setDiscussionForm] = useState(getLSGrid("discussion", grid.id) || {
     author_name: "",
     message: ""
   });
@@ -183,7 +182,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
       });
       onUpdate();
       setActiveTab("info");
-      deleteLocalStorage("volunteer")
+      deleteLSGrid("volunteer")
     } catch (error) {
       console.error('Failed to register volunteer:', error);
       alert('報名失敗，請稍後再試。');
@@ -243,7 +242,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
       });
       onUpdate(); 
       setActiveTab("info");
-      deleteLocalStorage("supply")
+      deleteLSGrid("supply")
     } catch (error) {
       console.error('Failed to register supply:', error);
       alert('捐贈失敗，請稍後再試。');
@@ -281,7 +280,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
         created_date: d.created_date || d.created_at || d.createdAt || d.created_at_date || null
       })) : [];
       setDiscussions(mapped);
-      deleteLocalStorage("discussion")
+      deleteLSGrid("discussion")
     } catch (error) {
       console.error('Failed to post discussion:', error);
       alert('發送訊息失敗，請稍後再試。');
@@ -292,17 +291,17 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
 
   const updateVolunteerForm = (newForm) => {  
     setVolunteerForm(newForm)
-    updateLocalStorage("volunteer", newForm)
+    updateLSGrid("volunteer", newForm)
   }
 
   const updateSupplyForm = (newForm) => {  
     setSupplyForm(newForm)
-    updateLocalStorage("supply", newForm)
+    updateLSGrid("supply", newForm)
   }
 
   const updateDiscussionForm = (newForm) => {  
     setDiscussionForm(newForm)
-    updateLocalStorage("discussion", newForm)
+    updateLSGrid("discussion", newForm)
   }
 
   return (

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -35,7 +35,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     grid = { ...grid, supplies_needed: [] };
   }
   const [activeTab, setActiveTab] = useState(defaultTab);
-  const [volunteerForm, setVolunteerForm] = useState(getLSGrid("volunteer", grid.id) || {
+  const [volunteerForm, setVolunteerForm] = useState(getLSGrid("volunteer") || {
     volunteer_name: "",
     volunteer_phone: "",
     volunteer_email: "",
@@ -44,7 +44,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     equipment: "",
     notes: ""
   });
-  const [supplyForm, setSupplyForm] = useState(getLSGrid("supply", grid.id) || {
+  const [supplyForm, setSupplyForm] = useState(getLSGrid("supply") || {
     donor_name: "",
     donor_phone: "",
     donor_email: "",
@@ -55,7 +55,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     delivery_time: "",
     notes: ""
   });
-  const [discussionForm, setDiscussionForm] = useState(getLSGrid("discussion", grid.id) || {
+  const [discussionForm, setDiscussionForm] = useState(getLSGrid("discussion") || {
     author_name: "",
     message: ""
   });

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -628,7 +628,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                           <Label htmlFor="supply_name">物資名稱 *</Label>
                           <Select
                               value={supplyForm.supply_name}
-                              onValueChange={(value) => setSupplyForm({...supplyForm, supply_name: value})}
+                              onValueChange={(value) => updateSupplyForm({...supplyForm, supply_name: value})}
                               required
                           >
                               <SelectTrigger>

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -290,18 +290,18 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
   };
 
   const updateVolunteerForm = (newForm) => {  
-    setVolunteerForm(newForm)
-    updateLSGrid("volunteer", newForm)
+    setVolunteerForm(newForm);
+    updateLSGrid("volunteer", newForm);
   }
 
   const updateSupplyForm = (newForm) => {  
-    setSupplyForm(newForm)
-    updateLSGrid("supply", newForm)
+    setSupplyForm(newForm);
+    updateLSGrid("supply", newForm);
   }
 
   const updateDiscussionForm = (newForm) => {  
-    setDiscussionForm(newForm)
-    updateLSGrid("discussion", newForm)
+    setDiscussionForm(newForm);
+    updateLSGrid("discussion", newForm);
   }
 
   return (

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -25,12 +25,18 @@ import {
 import { formatCreatedDate } from "@/lib/utils";
 
 export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = "info", onTabChange }) {
+  const updateLocalStorage = (targetFormName, targetForm) => 
+    { window.localStorage.setItem(targetFormName + "-" + grid.id, JSON.stringify(targetForm)); }
+
+  const getLocalStorage = (targetFormName) => JSON.parse(window.localStorage.getItem(targetFormName+ "-" + grid.id));
+  const deleteLocalStorage = (targetFormName) => {  window.localStorage.removeItem(targetFormName+ "-" + grid.id);  }
+
   // Normalize supplies_needed to an array to avoid runtime errors if backend returns null
   if (!Array.isArray(grid.supplies_needed)) {
     grid = { ...grid, supplies_needed: [] };
   }
   const [activeTab, setActiveTab] = useState(defaultTab);
-  const [volunteerForm, setVolunteerForm] = useState({
+  const [volunteerForm, setVolunteerForm] = useState(getLocalStorage("volunteer", grid.id) || {
     volunteer_name: "",
     volunteer_phone: "",
     volunteer_email: "",
@@ -39,7 +45,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     equipment: "",
     notes: ""
   });
-  const [supplyForm, setSupplyForm] = useState({
+  const [supplyForm, setSupplyForm] = useState(getLocalStorage("supply", grid.id) || {
     donor_name: "",
     donor_phone: "",
     donor_email: "",
@@ -50,7 +56,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
     delivery_time: "",
     notes: ""
   });
-  const [discussionForm, setDiscussionForm] = useState({
+  const [discussionForm, setDiscussionForm] = useState(getLocalStorage("discussion", grid.id) || {
     author_name: "",
     message: ""
   });
@@ -74,6 +80,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
         if (currentUser) {
           setUser(currentUser);
           const displayName = currentUser.name || currentUser.full_name || currentUser.email || '使用者';
+
           setVolunteerForm(prev => ({
             ...prev,
             volunteer_name: displayName,
@@ -157,13 +164,14 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
 
     setSubmitting(true);
     try {
+      
       await VolunteerRegistration.create({
         ...volunteerForm,
         grid_id: grid.id,
         skills: volunteerForm.skills.split(',').map(s => s.trim()).filter(Boolean),
         equipment: volunteerForm.equipment.split(',').map(s => s.trim()).filter(Boolean),
       });
-
+      
       setVolunteerForm({
         ...volunteerForm,
         // Preserve name/email if pre-filled by user, clear others
@@ -173,9 +181,9 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
         equipment: "",
         notes: ""
       });
-
       onUpdate();
       setActiveTab("info");
+      deleteLocalStorage("volunteer")
     } catch (error) {
       console.error('Failed to register volunteer:', error);
       alert('報名失敗，請稍後再試。');
@@ -202,7 +210,6 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
       // Find the selected supply to get its unit
       const selectedSupply = grid.supplies_needed.find(s => s.name === supplyForm.supply_name);
       const unit = selectedSupply ? selectedSupply.unit : "";
-
       // 1. Create the donation record
       await SupplyDonation.create({
         ...supplyForm,
@@ -234,9 +241,9 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
         delivery_time: "",
         notes: ""
       });
-
       onUpdate(); 
-      setActiveTab("info"); 
+      setActiveTab("info");
+      deleteLocalStorage("supply")
     } catch (error) {
       console.error('Failed to register supply:', error);
       alert('捐贈失敗，請稍後再試。');
@@ -274,6 +281,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
         created_date: d.created_date || d.created_at || d.createdAt || d.created_at_date || null
       })) : [];
       setDiscussions(mapped);
+      deleteLocalStorage("discussion")
     } catch (error) {
       console.error('Failed to post discussion:', error);
       alert('發送訊息失敗，請稍後再試。');
@@ -281,6 +289,21 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
       setSubmitting(false);
     }
   };
+
+  const updateVolunteerForm = (newForm) => {  
+    setVolunteerForm(newForm)
+    updateLocalStorage("volunteer", newForm)
+  }
+
+  const updateSupplyForm = (newForm) => {  
+    setSupplyForm(newForm)
+    updateLocalStorage("supply", newForm)
+  }
+
+  const updateDiscussionForm = (newForm) => {  
+    setDiscussionForm(newForm)
+    updateLocalStorage("discussion", newForm)
+  }
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -430,7 +453,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                       <Input
                         id="volunteer_name"
                         value={volunteerForm.volunteer_name}
-                        onChange={(e) => setVolunteerForm({...volunteerForm, volunteer_name: e.target.value})}
+                        onChange={(e) => updateVolunteerForm({...volunteerForm, volunteer_name: e.target.value})}
                         required
                       />
                     </div>
@@ -439,7 +462,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                       <Input
                         id="volunteer_phone"
                         value={volunteerForm.volunteer_phone}
-                        onChange={(e) => setVolunteerForm({...volunteerForm, volunteer_phone: e.target.value})}
+                        onChange={(e) => updateVolunteerForm({...volunteerForm, volunteer_phone: e.target.value})}
                       />
                       <p className="text-xs text-gray-500 mt-1 flex items-center gap-1">
                         <Info className="w-3 h-3"/>
@@ -454,7 +477,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                       id="available_time"
                       placeholder="例：2024/1/15 上午 9:00-12:00"
                       value={volunteerForm.available_time}
-                      onChange={(e) => setVolunteerForm({...volunteerForm, available_time: e.target.value})}
+                      onChange={(e) => updateVolunteerForm({...volunteerForm, available_time: e.target.value})}
                     />
                   </div>
 
@@ -464,7 +487,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                       id="skills"
                       placeholder="例：重機械操作, 電工, 水電"
                       value={volunteerForm.skills}
-                      onChange={(e) => setVolunteerForm({...volunteerForm, skills: e.target.value})}
+                      onChange={(e) => updateVolunteerForm({...volunteerForm, skills: e.target.value})}
                     />
                   </div>
 
@@ -474,8 +497,8 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                       id="equipment"
                       placeholder="例：鏟子, 水桶, 雨鞋"
                       value={volunteerForm.equipment}
-                      onChange={(e) => setVolunteerForm({...volunteerForm, equipment: e.target.value})}
-                    />
+                      onChange={(e) => updateVolunteerForm({...volunteerForm, equipment: e.target.value})}
+                   />
                   </div>
 
                   <div>
@@ -483,7 +506,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                     <Textarea
                       id="volunteer_notes"
                       value={volunteerForm.notes}
-                      onChange={(e) => setVolunteerForm({...volunteerForm, notes: e.target.value})}
+                      onChange={(e) => updateVolunteerForm({...volunteerForm, notes: e.target.value})}
                     />
                   </div>
 
@@ -581,7 +604,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                         <Input
                           id="donor_name"
                           value={supplyForm.donor_name}
-                          onChange={(e) => setSupplyForm({...supplyForm, donor_name: e.target.value})}
+                          onChange={(e) => updateSupplyForm({...supplyForm, donor_name: e.target.value})}
                           required
                         />
                       </div>
@@ -590,7 +613,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                         <Input
                           id="donor_phone"
                           value={supplyForm.donor_phone}
-                          onChange={(e) => setSupplyForm({...supplyForm, donor_phone: e.target.value})}
+                          onChange={(e) => updateSupplyForm({...supplyForm, donor_phone: e.target.value})}
                           required
                         />
                         <p className="text-xs text-gray-500 mt-1 flex items-center gap-1">
@@ -626,7 +649,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                           id="quantity"
                           type="number"
                           value={supplyForm.quantity}
-                          onChange={(e) => setSupplyForm({...supplyForm, quantity: e.target.value})}
+                          onChange={(e) => updateSupplyForm({...supplyForm, quantity: e.target.value})}
                           required
                           min="1"
                         />
@@ -639,7 +662,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                         id="delivery_time"
                         placeholder="例：今日下午 3:00"
                         value={supplyForm.delivery_time}
-                        onChange={(e) => setSupplyForm({...supplyForm, delivery_time: e.target.value})}
+                        onChange={(e) => updateSupplyForm({...supplyForm, delivery_time: e.target.value})}
                       />
                     </div>
 
@@ -648,7 +671,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                       <Textarea
                         id="supply_notes"
                         value={supplyForm.notes}
-                        onChange={(e) => setSupplyForm({...supplyForm, notes: e.target.value})}
+                        onChange={(e) => updateSupplyForm({...supplyForm, notes: e.target.value})}
                       />
                     </div>
 
@@ -715,7 +738,7 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
                           id="message"
                           placeholder="分享現場狀況、提問或協調事項..."
                           value={discussionForm.message}
-                          onChange={(e) => setDiscussionForm({...discussionForm, message: e.target.value})}
+                          onChange={(e) => updateDiscussionForm({...discussionForm, message: e.target.value})}
                           required
                         />
                       </div>

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -28,8 +28,8 @@ export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = 
   const updateLocalStorage = (targetFormName, targetForm) => 
     { window.localStorage.setItem(targetFormName + "-" + grid.id, JSON.stringify(targetForm)); }
 
-  const getLocalStorage = (targetFormName) => JSON.parse(window.localStorage.getItem(targetFormName+ "-" + grid.id));
-  const deleteLocalStorage = (targetFormName) => {  window.localStorage.removeItem(targetFormName+ "-" + grid.id);  }
+  const getLocalStorage = (targetFormName) => JSON.parse(window.localStorage.getItem(targetFormName + "-" + grid.id));
+  const deleteLocalStorage = (targetFormName) => {  window.localStorage.removeItem(targetFormName + "-" + grid.id);  }
 
   // Normalize supplies_needed to an array to avoid runtime errors if backend returns null
   if (!Array.isArray(grid.supplies_needed)) {

--- a/src/components/map/GridDetailModal.jsx
+++ b/src/components/map/GridDetailModal.jsx
@@ -25,7 +25,7 @@ import {
 import { formatCreatedDate, getLocalStorage, updateLocalStorage, deleteLocalStorage } from "@/lib/utils";
 
 export default function GridDetailModal({ grid, onClose, onUpdate, defaultTab = "info", onTabChange }) {
-  const updateLSGrid = (targetFormName, targetForm) => updateLocalStorage(targetFormName + "-" + grid.id, JSON.stringify(targetForm));
+  const updateLSGrid = (targetFormName, targetForm) => updateLocalStorage(targetFormName + "-" + grid.id, targetForm);
 
   const getLSGrid = (targetFormName) => getLocalStorage(targetFormName + "-" + grid.id);
   const deleteLSGrid = (targetFormName) => deleteLocalStorage(targetFormName + "-" + grid.id);

--- a/src/components/supplies/AddSupplyRequestModal.jsx
+++ b/src/components/supplies/AddSupplyRequestModal.jsx
@@ -45,8 +45,6 @@ export default function AddSupplyRequestModal({ isOpen, onClose, onSuccess, grid
   };
 
   const handleGridChange = (value) => {
-        console.log(value);
-
     setSelectedGridId(value);
     updateLocalStorage("NewSupplyRequest", { grid: value, supplies: supplies });
   };

--- a/src/components/supplies/AddSupplyRequestModal.jsx
+++ b/src/components/supplies/AddSupplyRequestModal.jsx
@@ -14,10 +14,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Grid, User } from '@/api/entities';
 import { Plus, Trash2 } from 'lucide-react';
 import { AskForLoginModal } from '../login/AskForLoginModal';
+import { getLocalStorage, updateLocalStorage } from '@/lib/utils';
 
 export default function AddSupplyRequestModal({ isOpen, onClose, onSuccess, grids }) {
-  const [selectedGridId, setSelectedGridId] = useState('');
-  const [supplies, setSupplies] = useState([{ name: '', quantity: '', unit: '' }]);
+  const [selectedGridId, setSelectedGridId] = useState(getLocalStorage("NewSupplyRequest") ? getLocalStorage("NewSupplyRequest").grid : '');
+  const [supplies, setSupplies] = useState(getLocalStorage("NewSupplyRequest") ? getLocalStorage("NewSupplyRequest").supplies : [{ name: '', quantity: '', unit: '' }]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [user, setUser] = useState(null);
@@ -43,10 +44,18 @@ export default function AddSupplyRequestModal({ isOpen, onClose, onSuccess, grid
     setSupplies(newSupplies);
   };
 
+  const handleGridChange = (value) => {
+        console.log(value);
+
+    setSelectedGridId(value);
+    updateLocalStorage("NewSupplyRequest", { grid: value, supplies: supplies });
+  };
+
   const handleSupplyChange = (index, field, value) => {
     const newSupplies = [...supplies];
     newSupplies[index][field] = value;
     setSupplies(newSupplies);
+    updateLocalStorage("NewSupplyRequest", { grid: selectedGridId, supplies: newSupplies });
   };
 
   const handleSubmit = async (e) => {
@@ -104,7 +113,7 @@ export default function AddSupplyRequestModal({ isOpen, onClose, onSuccess, grid
         <div className="space-y-4 py-4 max-h-[60vh] overflow-y-auto pr-2">
           <div>
             <Label htmlFor="grid-select" className="mb-2 block">救援網格 *</Label>
-            <Select value={selectedGridId} onValueChange={setSelectedGridId}>
+            <Select value={selectedGridId} onValueChange={(value) => handleGridChange(value)}>
               <SelectTrigger id="grid-select">
                 <SelectValue placeholder="請選擇網格" />
               </SelectTrigger>

--- a/src/components/supplies/AddSupplyRequestModal.jsx
+++ b/src/components/supplies/AddSupplyRequestModal.jsx
@@ -17,9 +17,9 @@ import { AskForLoginModal } from '../login/AskForLoginModal';
 import { getLocalStorage, updateLocalStorage } from '@/lib/utils';
 
 export default function AddSupplyRequestModal({ isOpen, onClose, onSuccess, grids }) {
-  const [selectedGridId, setSelectedGridId] = useState(getLocalStorage("NewSupplyRequest") ? getLocalStorage("NewSupplyRequest").grid : '');
-  const [supplies, setSupplies] = useState(getLocalStorage("NewSupplyRequest") ? getLocalStorage("NewSupplyRequest").supplies : [{ name: '', quantity: '', unit: '' }]);
-  const [submitting, setSubmitting] = useState(false);
+  const newSupplyRequestLS = getLocalStorage("NewSupplyRequest");
+  const [selectedGridId, setSelectedGridId] = useState(newSupplyRequestLS ? newSupplyRequestLS.grid : '');
+  const [supplies, setSupplies] = useState(newSupplyRequestLS ? newSupplyRequestLS.supplies : [{ name: '', quantity: '', unit: '' }]);  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [user, setUser] = useState(null);
   const [agreedToTerms, setAgreedToTerms] = useState(false);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -21,3 +21,7 @@ export function formatCreatedDate(createdTimestamp) {
   else if (createdDate == qiantian) return "前天 " + createdTime;
   else return createdDate.split("2025/")[1] + " " + createdTime;
 }
+
+export const updateLocalStorage = (key, value) => { window.localStorage.setItem(key, value); }
+export const getLocalStorage = (key) => JSON.parse(window.localStorage.getItem(key));
+export const deleteLocalStorage = (key) => {  window.localStorage.removeItem(key);  }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,7 +24,10 @@ export function formatCreatedDate(createdTimestamp) {
 
 export const updateLocalStorage = (key, value) => window.localStorage.setItem(key, JSON.stringify(value));
 export const getLocalStorage = (key) => {
-  try { return JSON.parse(window.localStorage.getItem(key));}
-  catch (e) { return null; }
+  try { return JSON.parse(window.localStorage.getItem(key)); }
+  catch (e) { 
+    console.error("Error getting or parsing localStorage item:", e); 
+    return null;
+  }
 }
 export const deleteLocalStorage = (key) => window.localStorage.removeItem(key);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -23,5 +23,8 @@ export function formatCreatedDate(createdTimestamp) {
 }
 
 export const updateLocalStorage = (key, value) => window.localStorage.setItem(key, JSON.stringify(value));
-export const getLocalStorage = (key) => JSON.parse(window.localStorage.getItem(key));
+export const getLocalStorage = (key) => {
+  try { return JSON.parse(window.localStorage.getItem(key));}
+  catch (e) { return null; }
+}
 export const deleteLocalStorage = (key) => window.localStorage.removeItem(key);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -22,6 +22,6 @@ export function formatCreatedDate(createdTimestamp) {
   else return createdDate.split("2025/")[1] + " " + createdTime;
 }
 
-export const updateLocalStorage = (key, value) => { window.localStorage.setItem(key, value); }
+export const updateLocalStorage = (key, value) => window.localStorage.setItem(key, JSON.stringify(value));
 export const getLocalStorage = (key) => JSON.parse(window.localStorage.getItem(key));
-export const deleteLocalStorage = (key) => {  window.localStorage.removeItem(key);  }
+export const deleteLocalStorage = (key) => window.localStorage.removeItem(key);


### PR DESCRIPTION
# 功能說明

在填寫以下表單時，將未送出的表單資料以 JSON 字串暫存於瀏覽器 LocalStorage 中：
- Grid 中的三個表單（志工報名、物資捐贈、討論區）
- 右上角「我要人力」的新增人力需求表單
- 物資管理 >「新增物資需求」表單


## LocalStorage 儲存配置
- Grid中三表單的鍵為`<表單名稱>-<grid.id>`，值為對應表單的JSON格式，開啟該Grid可帶入先前輸入的值。
- 新增人力需求表單的鍵為`NewGrid`，值為該表單的JSON格式。
- 新增物資需求表單的鍵為`NewSupplyRequest`，值為一個`SupplyRequest`對象，結構如以下所示：
```ts
class SupplyRequest {
    grid: string;
    supplies: <Supply>[]
}

class Supply {
    name: string,
    quantity: string,
    unit: string
}
```
其中 `grid` 為選中的網格的 ID，即`SelectedGridId`；`supplies` 為網格物資需求的 JSON 格式表達，為一個或多個`Supply`對象組成的陣列。

# 修改前
[修改前錄影](https://youtu.be/PbOLFaJvMgI)

# 修改後
[修改後錄影](https://youtu.be/atwhX4H69b4)

DevTool Local Storage 概覽
<img width="1779" height="1094" alt="image" src="https://github.com/user-attachments/assets/970d747b-00f8-4bfb-b8c9-01975dc8f660" />


## PR 檢核清單（Review Checklist）
- [X] 有對應 Issue 或清楚描述 (https://github.com/shovel-heroes-org/shovel-heroes/issues/96)
- [x] 有測試或可手動驗收步驟
- [X] 通過 Lint/Build
- [X] 不引入敏感資訊、金鑰或多餘權限
- [ ] ~~對文件（README/CLAUDE.md/SECURITY.md/OpenAPI）同步更新~~ (N/A)

